### PR TITLE
Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please use https://g.co/vulnz to report security vulnerabilities.
+
+We use https://g.co/vulnz for our intake and triage. For valid issues we will do
+coordination and disclosure here on GitHub (including using a GitHub Security
+Advisory when necessary).
+
+The Google Security Team will process your report within a day, and respond
+within a week (although it will depend on the severity of your report).


### PR DESCRIPTION
The policy was copied from the one on bazelbuild/bazel, and will be used by default on bazelbuild org